### PR TITLE
Add splitting features for kana and romaji

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In this example `hiragana` will have the value `ひらがな`.
 
 ```javascript
 var katakana = hepburn.toKatakana("KATAKANA");
-var tokyo = hepburn.toKatakana("TŌKYŌ"); 
+var tokyo = hepburn.toKatakana("TŌKYŌ");
 ```
 
 Converts a string containing Romaji to Katakana.
@@ -65,6 +65,28 @@ What this methods fixes:
 * Changing usage of NN into N', for example "Shunnei" becomes "Shun'ei".
 * Converting the usage of OU and OH (to indicate a long vowel) into OO.
 * Correct old usages [Nihon-shiki romanization](https://en.wikipedia.org/wiki/Nihon-shiki_romanization) into Hepburn form. A full list of the conversions can be found in the `hepburn.js` file. For example "Eisyosai" becomes "Eishosai" and "Yoshihuji" becomes "Yoshifuji".
+
+### splitKana(string)
+
+```javascript
+var hiragana = hepburn.splitKana("ひらがな");
+var tokyo = hepburn.splitKana("トーキョー");
+```
+
+Splits a string containing Katakana or Hiragana into a syllables array.
+
+In this example `hiragana` will have the value `["ひ", "ら", "が", "な"]` and `tokyo` will have the value `["トー", "キョー"]`.
+
+### splitRomaji(string)
+
+```javascript
+var tokyo = hepburn.splitRomaji("TŌKYŌ");
+var pakkingu = hepburn.splitRomaji("PAKKINGU");
+```
+
+Splits a string containing Romaji into a syllables array.
+
+In this example `tokyo` will have the value `["TŌ", "KYŌ"]` and `pakkingu` will have the value `["PAK", "KI", "N", "GU"]`.
 
 ### containsHiragana(string)
 

--- a/lib/hepburn.js
+++ b/lib/hepburn.js
@@ -105,6 +105,21 @@ var katakanaTrigraphs = {
   "ピャー": "PYĀ", "ピュー": "PYŪ", "ピョー": "PYŌ"
 };
 
+var choonpu = "ー";
+
+var yoonHiragana = "ぁぃぅぇぉゃゅょゎゕ";
+var yoonKatakana = "ァィゥェォャュョヮヵ";
+
+var sokuonHiragana = "っ";
+var sokuonKatakana = "ッ";
+
+var sokuons = sokuonKatakana + sokuonHiragana;
+
+var katakanaSplitCombinators = choonpu + yoonKatakana + sokuonKatakana;
+var hiraganaSplitCombinators = choonpu + yoonHiragana + sokuonHiragana;
+
+var kanaSplitCombinators = katakanaSplitCombinators + hiraganaSplitCombinators;
+
 // Used to convert old Nihon-Shiki style romaji into the modern Hepburn form.
 // Source: http://nayuki.eigenstate.org/page/variations-on-japanese-romanization
 var nihonShiki = {
@@ -195,8 +210,7 @@ exports.fromKana = function(str) {
   str = bulkReplace(str, katakanaMonographs);
 
   // Correct use of sokuon
-  str = str.replace(/っC/g, "TC").replace(/っ(.)/g, "$1$1");
-  str = str.replace(/ッC/g, "TC").replace(/ッ(.)/g, "$1$1");
+  str = str.replace(/[っッ]C/g, "TC").replace(/[っッ](.)/g, "$1$1");
 
   // Correct usage of N' (M' is a common mistake)
   str = str.replace(/[NM]'([^YAEIOU]|$)/g, "N$1");
@@ -271,6 +285,57 @@ exports.cleanRomaji = function(str) {
 
   return str;
 };
+
+exports.splitKana = function(str) {
+  return str.split("").reduce(function(r, h) {
+    // if current kana is a combinator
+    // or previous syllable and current character both aren't kanas
+    // then merge with previous syllable if any
+    if (
+      r[r.length - 1] && h.trim() &&
+        (kanaSplitCombinators.includes(h) ||
+         (!exports.containsHiragana(r[r.length - 1]) &&
+          !exports.containsKatakana(r[r.length - 1]) &&
+          (!exports.containsHiragana(h) && !exports.containsKatakana(h))))
+    ) {
+      r[r.length - 1] += h;
+    } else {
+      r.push(h);
+    }
+
+    return r;
+  }, []);
+};
+
+// known issue: unclean romaji might get too chopped up
+// e.g. "CHYA" becomes ["C", "HYA"]
+exports.splitRomaji = function(str) {
+  return exports.splitKana(exports.toKatakana(str)).map((k, i, ks) => {
+    // if syllable's last character is a sokuon
+    // add the first letter of the following syllable if any
+    // to the end of current syllable
+    if (i < ks.length - 1 && sokuons.includes(k.slice(-1)[0])) {
+      const next = ks[i + 1];
+      const nextRomaji =
+              exports.containsHiragana(next) || exports.containsKatakana(next)
+              ? exports.fromKana(next)
+              : next;
+
+      var nextLetter = nextRomaji[0]
+
+      // correct CC/TC use of sokuon
+      if (nextLetter === 'C') {
+        nextLetter = 'T'
+      }
+
+      const r = exports.fromKana(k.slice(0, -1)) + nextLetter;
+
+      return r;
+    }
+
+    return exports.fromKana(k);
+  })
+}
 
 exports.containsHiragana = function(str) {
   return new RegExp(Object.keys(hiraganaMonographs).join('|')).test(str);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node tests/all && node tests/macrons"
+    "test": "node tests/all && node tests/macrons && echo \"tests passed successfully\""
   },
   "keywords": [
     "japanese",

--- a/tests/all.js
+++ b/tests/all.js
@@ -532,6 +532,50 @@ var cleanTests = {
   "CHYAASHYUU": "CHAASHUU"
 };
 
+var hiraganaSplitTests = {
+  "ひらがな": ["ひ", "ら", "が", "な"],
+  "あいうえお かきくけこ": [
+    "あ", "い", "う", "え", "お",
+    " ",
+    "か", "き", "く", "け", "こ"
+  ],
+  "きゃきゅきょ": ["きゃ", "きゅ", "きょ"],
+  "あんこ": ["あ", "ん", "こ"],
+  "どらえもん": ["ど", "ら", "え", "も", "ん"],
+  "だんな": ["だ", "ん", "な"],
+  "へっぽこ": ["へっ", "ぽ", "こ"],
+  "きょうと": ["きょ", "う", "と"],
+  "こんにちは": ["こ", "ん", "に", "ち", "は"]
+}
+
+var katakanaSplitTests = {
+  "カタカナ": ["カ", "タ", "カ", "ナ"],
+  "カタ カナ": ["カ", "タ", " ", "カ", "ナ"],
+  "マッモト": ["マッ", "モ", "ト"],
+  "コミッター": ["コ", "ミッ", "ター"],
+  "リード": ["リー", "ド"],
+  "リユース": ["リ", "ユー", "ス"],
+  "ショップ": ["ショッ", "プ"]
+}
+
+var romajiSplitTests = {
+  "KATAKANA": ["KA", "TA", "KA", "NA"],
+  "TOKYO": ["TO", "KYO"],
+  "TOOKYOO": ["TO", "O", "KYO", "O"],
+  "TOUKYOU": ["TO", "U", "KYO", "U"],
+  "MAKKUDONARUDO": ["MAK", "KU", "DO", "NA", "RU", "DO"],
+  "MADONNA": ["MA", "DO", "N", "NA"],
+  "TABAKO": ["TA", "BA", "KO"],
+  "ITCHOO": ["IT", "CHO", "O"],
+  "TĀMINARU": ["TĀ", "MI", "NA", "RU"],
+  "MĪTOAPPU": ["MĪ", "TO", "AP", "PU"],
+  "MŪBU": ["MŪ", "BU"],
+  "PĒSU": ["PĒ", "SU"],
+  "TŌKYŌ": ["TŌ", "KYŌ"],
+  "BYAKKUGAN": ["BYAK", "KU", "GA", "N"],
+  "DANNA SAMA": ["DA", "N", "NA", " ", "SA", "MA"]
+};
+
 for (var hiragana in hiraganaTests) {
   assert.equal(hepburn.fromKana(hiragana), hiraganaTests[hiragana], "Hiragana conversion failed on " + hiragana);
 }
@@ -553,6 +597,19 @@ for (var romaji in toHiraganaTests) {
 for (var hiragana in cleanTests) {
   assert.equal(hepburn.cleanRomaji(hiragana), cleanTests[hiragana], "Failed to clean " + hiragana);
 }
+
+for (var hiragana in hiraganaSplitTests) {
+  assert.deepEqual(hepburn.splitKana(hiragana), hiraganaSplitTests[hiragana], "Failed to split " + hiragana);
+}
+
+for (var katakana in katakanaSplitTests) {
+  assert.deepEqual(hepburn.splitKana(katakana), katakanaSplitTests[katakana], "Failed to split kana " + katakana);
+}
+
+for (var romaji in romajiSplitTests) {
+  assert.deepEqual(hepburn.splitRomaji(romaji), romajiSplitTests[romaji], "Failed to split romaji " + romaji);
+}
+
 
 Object.keys(hiraganaTests).forEach(function(key){
   assert(hepburn.containsHiragana(key));


### PR DESCRIPTION
Hi there,

As discussed in  https://github.com/lovell/hepburn/issues/12, here are two new features for string splitting of both Kana and Romaji.

Known issue: unclean Romaji will get chopped up badly.
E.g.: 
```js
hepburn.splitRomaji("CHYA")
// ["C", "HYA"]
```

Cleaning Romaji strings before splitting might be hazardous, see https://github.com/lovell/hepburn/issues/16.

Cheers.